### PR TITLE
Better table replication for RemoteProperty objects

### DIFF
--- a/src/Knit/KnitClient.lua
+++ b/src/Knit/KnitClient.lua
@@ -55,7 +55,7 @@ local function BuildService(serviceName, folder)
 	end
 	if (folder:FindFirstChild("RP")) then
 		for _,rp in ipairs(folder.RP:GetChildren()) do
-			if (rp:IsA("ValueBase")) then
+			if (rp:IsA("ValueBase") or rp:IsA("RemoteEvent")) then
 				service[rp.Name] = RemoteProperty.new(rp)
 			end
 		end

--- a/src/Knit/KnitServer.lua
+++ b/src/Knit/KnitServer.lua
@@ -48,8 +48,10 @@ local function GetFolderOrCreate(parent, name)
 end
 
 
-local function AddToRepFolder(service, remoteObj)
-	if (remoteObj:IsA("RemoteFunction")) then
+local function AddToRepFolder(service, remoteObj, folderOverride)
+	if (folderOverride) then
+		remoteObj.Parent = GetFolderOrCreate(service._knit_rep_folder, folderOverride)
+	elseif (remoteObj:IsA("RemoteFunction")) then
 		remoteObj.Parent = GetFolderOrCreate(service._knit_rep_folder, "RF")
 	elseif (remoteObj:IsA("RemoteEvent")) then
 		remoteObj.Parent = GetFolderOrCreate(service._knit_rep_folder, "RE")
@@ -118,7 +120,7 @@ function KnitServer.BindRemoteProperty(service, propName, prop)
 	assert(service._knit_rp[propName] == nil, "RemoteProperty \"" .. propName .. "\" already exists")
 	prop._object.Name = propName
 	service._knit_rp[propName] = prop
-	AddToRepFolder(service, prop._object)
+	AddToRepFolder(service, prop._object, "RP")
 end
 
 


### PR DESCRIPTION
The justification behind this change is to replicate tables using RemoteFunctions and RemoteEvents instead of StringValue. StringValues force JSON serialization, which only allows primitive data, and thus instances cannot be contained within the table data. This is _not_ the case for RFs and REs, meaning users can include instances within table data and it will replicate just fine (assuming the instance is available to the clients).