### PR TITLE
typeof(true|false) == "boolean" not "bool"

### DIFF
--- a/src/Knit/Util/Remote/RemoteProperty.lua
+++ b/src/Knit/Util/Remote/RemoteProperty.lua
@@ -31,7 +31,7 @@ local Signal = require(script.Parent.Parent.Signal)
 local httpService = game:GetService("HttpService")
 
 local typeClassMap = {
-	bool = "BoolValue";
+	boolean = "BoolValue";
 	string = "StringValue";
 	table = "StringValue";
 	CFrame = "CFrameValue";


### PR DESCRIPTION
While messing around with the framework, I noticed that it said that a bool was not a supported value type, so I investigated and found that the wrong type was used in the type class map.

Though it may be necessary to include "bool" as well. All I did was change it to "boolean"