### PR TITLE
Add ability to execute function immediately in DelayRepeat

### DIFF
--- a/docs/util.md
+++ b/docs/util.md
@@ -40,6 +40,42 @@ Thread.Delay(1, function() print("Hola") end)
 Thread.DelayRepeat(1, function() print("Hello again") end)
 ```
 
+DelayRepeat has an optional Behavior parameter, which can be used to switch the behavior between an initial delay (default) or immediate execution before the first delay. For instance, if you want the function to fire immediately before starting the delay loop, use the Immediate behavior:
+
+```lua
+-- Fire the function immediately:
+Thread.DelayRepeat(1, function()
+	print("Hello")
+end, Thread.DelayRepeatBehavior.Immediate)
+
+-- Fire the function after the first 1 second delay (default behavior):
+Thread.DelayRepeat(1, function()
+	print("Hello")
+end, Thread.DelayRepeatBehavior.Delayed)
+```
+
+All of these functions can also be given arguments, as a vararg list at the end of the Thread function call. For instance:
+
+```lua
+Thread.Spawn(function(someMessage)
+	print(someMessage)
+end, someMessage)
+```
+
+The caveat with the above is dealing with DelayRepeat, where the behavior must first be defined before the vararg list:
+
+```lua
+-- Will work:
+Thread.DelayRepeat(1, function(message)
+	print(message)
+end, Thread.DelayRepeatBehavior.Delayed, "Hello world!")
+
+-- Will throw an error as an unknown behavior:
+Thread.DelayRepeat(1, function(message)
+	print(message)
+end, "Hello world!")
+```
+
 The Delay and DelayRepeat functions also return an event listener, so they can be cancelled if needed:
 
 ```lua

--- a/src/Knit/Util/Symbol.lua
+++ b/src/Knit/Util/Symbol.lua
@@ -2,6 +2,15 @@
 -- Stephen Leitnick
 -- December 27, 2020
 
+--[[
+
+	symbol = Symbol.new(id: string [, scope: Symbol])
+
+	Symbol.Is(obj: any): boolean
+	Symbol.IsInScope(obj: any, scope: Symbol): boolean
+
+--]]
+
 
 local CLASSNAME = "Symbol"
 
@@ -28,7 +37,7 @@ function Symbol.Is(obj)
 end
 
 
-function Symbol.IsScope(obj, scope)
+function Symbol.IsInScope(obj, scope)
 	return (Symbol.Is(obj) and obj._scope == scope)
 end
 

--- a/src/Knit/Util/Symbol.lua
+++ b/src/Knit/Util/Symbol.lua
@@ -1,0 +1,41 @@
+-- Symbol
+-- Stephen Leitnick
+-- December 27, 2020
+
+
+local CLASSNAME = "Symbol"
+
+local Symbol = {}
+Symbol.__index = Symbol
+
+
+function Symbol.new(id, scope)
+	assert(id ~= nil, "Symbol ID cannot be nil")
+	if (scope ~= nil) then
+		assert(Symbol.Is(scope), "Scope must be a Symbol or nil")
+	end
+	local self = setmetatable({
+		ClassName = CLASSNAME;
+		_id = id;
+		_scope = scope;
+	}, Symbol)
+	return self
+end
+
+
+function Symbol.Is(obj)
+	return (type(obj) == "table" and getmetatable(obj) == Symbol)
+end
+
+
+function Symbol.IsScope(obj, scope)
+	return (Symbol.Is(obj) and obj._scope == scope)
+end
+
+
+function Symbol:__tostring()
+	return ("Symbol<%s>"):format(self._id)
+end
+
+
+return Symbol

--- a/src/Knit/Util/Thread.lua
+++ b/src/Knit/Util/Thread.lua
@@ -7,9 +7,9 @@
 	Thread.SpawnNow(func, ...)
 	Thread.Spawn(func, ...)
 	Thread.Delay(waitTime, func, ...)
-	Thread.DelayRepeat(waitTime, func, ...)
+	Thread.DelayRepeat(waitTime, func, immediate, ...)
 
-	SpawnNow(Function func, Arguments...)
+	SpawnNow(func: (...any) -> void, ...args)
 
 		>	Uses a BindableEvent to spawn a new thread
 			immediately. More performance-intensive than
@@ -20,7 +20,7 @@
 			right away, otherwise use Thread.Spawn for
 			the sake of performance.
 
-	Spawn(Function func, Arguments...)
+	Spawn(func: (...any) -> void, ...args)
 
 		>	Uses RunService's Heartbeat to spawn a new
 			thread on the next heartbeat and then
@@ -30,7 +30,7 @@
 			will have a short delay of 1 frame before
 			calling the function.
 
-	Delay(Number waitTime, Function func, Arguments...)
+	Delay(waitTime: number, func: (...any) -> void, ...args)
 
 		>	The same as Thread.Spawn, but waits to call
 			the function until the in-game time as elapsed
@@ -40,7 +40,7 @@
 			so the delay can be cancelled by disconnecting
 			the returned connection.
 
-	DelayRepeat(Number intervalTime, Function func, Arguments...)
+	DelayRepeat(intervalTime: number, func: (...any) -> void, immedate: boolean, ...args)
 
 		>	The same as Thread.Delay, except it repeats
 			indefinitely.
@@ -148,9 +148,9 @@ function Thread.Delay(waitTime, func, ...)
 end
 
 
-function Thread.DelayRepeat(intervalTime, func, ...)
+function Thread.DelayRepeat(intervalTime, func, immediate, ...)
 	local args = table.pack(...)
-	local nextExecuteTime = (time() + intervalTime)
+	local nextExecuteTime = (time() + (immediate and 0 or intervalTime))
 	local hb
 	hb = heartbeat:Connect(function()
 		if (time() >= nextExecuteTime) then

--- a/src/Knit/Util/Thread.lua
+++ b/src/Knit/Util/Thread.lua
@@ -167,7 +167,7 @@ function Thread.DelayRepeat(intervalTime, func, behavior, ...)
 	if (behavior == nil) then
 		behavior = Thread.DelayRepeatBehavior.Delayed
 	end
-	assert(Symbol.IsScope(behavior, threadScope), "Invalid behavior")
+	assert(Symbol.IsInScope(behavior, threadScope), "Invalid behavior")
 	local immediate = (behavior == Thread.DelayRepeatBehavior.Immediate)
 	local nextExecuteTime = (time() + (immediate and 0 or intervalTime))
 	local hb

--- a/src/Knit/Util/Thread.lua
+++ b/src/Knit/Util/Thread.lua
@@ -6,12 +6,12 @@
 
 	Thread.DelayRepeatBehavior { Delayed, Immediate }
 
-	Thread.SpawnNow(func: (...any) -> void, ...any)
-	Thread.Spawn(func: (...any) -> void, ...any)
-	Thread.Delay(waitTime: number, func: (...any) -> void, ...any)
-	Thread.DelayRepeat(waitTime: number, func: (...any) -> void, behavior: DelayRepeatBehavior, ...any)
+	Thread.SpawnNow(func: (...any) -> void, [...any])
+	Thread.Spawn(func: (...any) -> void, [...any])
+	Thread.Delay(waitTime: number, func: (...any) -> void [, ...any])
+	Thread.DelayRepeat(waitTime: number, func: (...any) -> void [, behavior: DelayRepeatBehavior, ...any])
 
-	SpawnNow(func: (...any) -> void, ...args)
+	SpawnNow(func: (...any) -> void [, ...args])
 
 		>	Uses a BindableEvent to spawn a new thread
 			immediately. More performance-intensive than
@@ -22,7 +22,7 @@
 			right away, otherwise use Thread.Spawn for
 			the sake of performance.
 
-	Spawn(func: (...any) -> void, ...args)
+	Spawn(func: (...any) -> void [, ...args])
 
 		>	Uses RunService's Heartbeat to spawn a new
 			thread on the next heartbeat and then
@@ -32,7 +32,7 @@
 			will have a short delay of 1 frame before
 			calling the function.
 
-	Delay(waitTime: number, func: (...any) -> void, ...args)
+	Delay(waitTime: number, func: (...any) -> void [, ...args])
 
 		>	The same as Thread.Spawn, but waits to call
 			the function until the in-game time as elapsed
@@ -42,7 +42,7 @@
 			so the delay can be cancelled by disconnecting
 			the returned connection.
 
-	DelayRepeat(intervalTime: number, func: (...any) -> void, behavior: DelayRepeatBehavior, ...args)
+	DelayRepeat(intervalTime: number, func: (...any) -> void [, behavior: DelayRepeatBehavior, ...args])
 
 		>	The same as Thread.Delay, except it repeats
 			indefinitely.


### PR DESCRIPTION
`Thread.DelayRepeat` always waits the initial time interval before the first execution of its given function. In some use-cases, it would be helpful for the function to be executed right away (in the same way that `Thread.Spawn` would execute it right away; after a single heartbeat).

This change introduces a _non_-backwards-compatible change to the function signature, where an `immediate` boolean parameter is added: `Thread.DelayRepat(intervalTime, func, immediate, ...)`. This would break existing code that relies on the varargs `...` to pass parameters to the function. The fix would be to add `false` where the `immediate` parameter would now be.