### PR TITLE
Rename RemoteEvent to RemoteSignal

### DIFF
--- a/docs/util.md
+++ b/docs/util.md
@@ -142,40 +142,40 @@ Fetch("https://www.example.com")
 
 --------------------
 
-## [RemoteEvent](https://github.com/Sleitnick/Knit/blob/main/src/Knit/Util/Remote/RemoteEvent.lua)
+## [RemoteSignal](https://github.com/Sleitnick/Knit/blob/main/src/Knit/Util/Remote/RemoteSignal.lua)
 
-The [RemoteEvent](https://github.com/Sleitnick/Knit/blob/main/src/Knit/Util/Remote/RemoteEvent.lua) module wraps the RemoteEvent object and is used within services and controllers. The only time a developer should ever have to instantiate a RemoteEvent is within the `Client` table of a service. The behavior differs between the server and the client.
+The [RemoteSignal](https://github.com/Sleitnick/Knit/blob/main/src/Knit/Util/Remote/RemoteSignal.lua) module wraps the RemoteEvent object and is used within services and controllers. The only time a developer should ever have to instantiate a RemoteSignal is within the `Client` table of a service. The behavior differs between the server and the client.
 
 ```lua
 -- Server-side
-local remoteEvent = RemoteEvent.new()
+local remoteSignal = RemoteSignal.new()
 
-remoteEvent:Fire(player, ...)
-remoteEvent:FireExcept(player, ...)
-remoteEvent:FireAll(...)
-remoteEvent:Wait()
-remoteEvent:Destroy()
+remoteSignal:Fire(player, ...)
+remoteSignal:FireExcept(player, ...)
+remoteSignal:FireAll(...)
+remoteSignal:Wait()
+remoteSignal:Destroy()
 
-local connection = remoteEvent:Connect(functionHandler(player, ...))
+local connection = remoteSignal:Connect(functionHandler(player, ...))
 connection:IsConnected()
 connection:Disconnect()
 ```
 
 ```lua
 -- Client side
-local remoteEvent = RemoteEvent.new(remoteEventObject)
+local remoteSignal = RemoteSignal.new(remoteEventObject)
 
-remoteEvent:Fire(...)
-remoteEvent:Wait()
-remoteEvent:Destroy()
+remoteSignal:Fire(...)
+remoteSignal:Wait()
+remoteSignal:Destroy()
 
-local connection = remoteEvent:Connect(functionHandler(...))
+local connection = remoteSignal:Connect(functionHandler(...))
 connection:IsConnected()
 connection:Disconnect()
 ```
 
 !!! note
-	Knit manages RemoteEvent objects on the client, so developers should never have to instantiate these themselves on the client unless creating completely custom workflows.
+	Knit manages RemoteSignal objects on the client, so developers should never have to instantiate these themselves on the client unless creating completely custom workflows.
 
 --------------------
 

--- a/src/Knit/KnitClient.lua
+++ b/src/Knit/KnitClient.lua
@@ -17,7 +17,7 @@ KnitClient.Util = script.Parent.Util
 local Promise = require(KnitClient.Util.Promise)
 local Thread = require(KnitClient.Util.Thread)
 local Ser = require(KnitClient.Util.Ser)
-local RemoteEvent = require(KnitClient.Util.Remote.RemoteEvent)
+local RemoteSignal = require(KnitClient.Util.Remote.RemoteSignal)
 local RemoteProperty = require(KnitClient.Util.Remote.RemoteProperty)
 local TableUtil = require(KnitClient.Util.TableUtil)
 
@@ -49,7 +49,7 @@ local function BuildService(serviceName, folder)
 	if (folder:FindFirstChild("RE")) then
 		for _,re in ipairs(folder.RE:GetChildren()) do
 			if (re:IsA("RemoteEvent")) then
-				service[re.Name] = RemoteEvent.new(re)
+				service[re.Name] = RemoteSignal.new(re)
 			end
 		end
 	end

--- a/src/Knit/Util/Remote/RemoteSignal.lua
+++ b/src/Knit/Util/Remote/RemoteSignal.lua
@@ -1,25 +1,25 @@
--- RemoteEvent
+-- RemoteSignal
 -- Stephen Leitnick
 
 --[[
 	
 	[Server]
-		event = RemoteEvent.new()
-		event:Fire(player, ...)
-		event:FireAll(...)
-		event:FireExcept(player, ...)
-		event:Wait()
-		event:Destroy()
-		connection = event:Connect(functionHandler(player, ...))
+		remoteSignal = RemoteSignal.new()
+		remoteSignal:Fire(player, ...)
+		remoteSignal:FireAll(...)
+		remoteSignal:FireExcept(player, ...)
+		remoteSignal:Wait()
+		remoteSignal:Destroy()
+		connection = remoteSignal:Connect(functionHandler(player, ...))
 		connection:Disconnect()
 		connection:IsConnected()
 
 	[Client]
-		event = RemoteEvent.new(remoteEventObject)
-		event:Fire(...)
-		event:Wait()
-		event:Destroy()
-		connection = event:Connect(functionHandler(...))
+		remoteSignal = RemoteSignal.new(remoteEventObject)
+		remoteSignal:Fire(...)
+		remoteSignal:Wait()
+		remoteSignal:Destroy()
+		connection = remoteSignal:Connect(functionHandler(...))
 		connection:Disconnect()
 		connection:IsConnected()
 
@@ -30,31 +30,31 @@ local IS_SERVER = game:GetService("RunService"):IsServer()
 local Players = game:GetService("Players")
 local Ser = require(script.Parent.Parent.Ser)
 
-local RemoteEvent = {}
-RemoteEvent.__index = RemoteEvent
+local RemoteSignal = {}
+RemoteSignal.__index = RemoteSignal
 
-function RemoteEvent.Is(object)
-	return (type(object) == "table" and getmetatable(object) == RemoteEvent)
+function RemoteSignal.Is(object)
+	return (type(object) == "table" and getmetatable(object) == RemoteSignal)
 end
 
 if (IS_SERVER) then
 
-	function RemoteEvent.new()
+	function RemoteSignal.new()
 		local self = setmetatable({
 			_remote = Instance.new("RemoteEvent");
-		}, RemoteEvent)
+		}, RemoteSignal)
 		return self
 	end
 
-	function RemoteEvent:Fire(player, ...)
+	function RemoteSignal:Fire(player, ...)
 		self._remote:FireClient(player, Ser.SerializeArgsAndUnpack(...))
 	end
 
-	function RemoteEvent:FireAll(...)
+	function RemoteSignal:FireAll(...)
 		self._remote:FireAllClients(Ser.SerializeArgsAndUnpack(...))
 	end
 
-	function RemoteEvent:FireExcept(player, ...)
+	function RemoteSignal:FireExcept(player, ...)
 		local args = Ser.SerializeArgs(...)
 		for _,plr in ipairs(Players:GetPlayers()) do
 			if (plr ~= player) then
@@ -63,17 +63,17 @@ if (IS_SERVER) then
 		end
 	end
 
-	function RemoteEvent:Wait()
+	function RemoteSignal:Wait()
 		return self._remote.OnServerEvent:Wait()
 	end
 
-	function RemoteEvent:Connect(handler)
+	function RemoteSignal:Connect(handler)
 		return self._remote.OnServerEvent:Connect(function(player, ...)
 			handler(player, Ser.DeserializeArgsAndUnpack(...))
 		end)
 	end
 
-	function RemoteEvent:Destroy()
+	function RemoteSignal:Destroy()
 		self._remote:Destroy()
 		self._remote = nil
 	end
@@ -119,25 +119,25 @@ else
 
 	Connection.Destroy = Connection.Disconnect
 
-	function RemoteEvent.new(remoteEvent)
+	function RemoteSignal.new(remoteEvent)
 		assert(typeof(remoteEvent) == "Instance", "Argument #1 (RemoteEvent) expected Instance; got " .. typeof(remoteEvent))
 		assert(remoteEvent:IsA("RemoteEvent"), "Argument #1 (RemoteEvent) expected RemoteEvent; got" .. remoteEvent.ClassName)
 		local self = setmetatable({
 			_remote = remoteEvent;
 			_connections = {};
-		}, RemoteEvent)
+		}, RemoteSignal)
 		return self
 	end
 
-	function RemoteEvent:Fire(...)
+	function RemoteSignal:Fire(...)
 		self._remote:FireServer(Ser.SerializeArgsAndUnpack(...))
 	end
 
-	function RemoteEvent:Wait()
+	function RemoteSignal:Wait()
 		return Ser.DeserializeArgsAndUnpack(self._remote.OnClientEvent:Wait())
 	end
 
-	function RemoteEvent:Connect(handler)
+	function RemoteSignal:Connect(handler)
 		local connection = Connection.new(self, self._remote.OnClientEvent:Connect(function(...)
 			handler(Ser.DeserializeArgsAndUnpack(...))
 		end))
@@ -145,7 +145,7 @@ else
 		return connection
 	end
 
-	function RemoteEvent:Destroy()
+	function RemoteSignal:Destroy()
 		for _,c in ipairs(self._connections) do
 			if (c._conn) then
 				c._conn:Disconnect()
@@ -157,4 +157,4 @@ else
 
 end
 
-return RemoteEvent
+return RemoteSignal

--- a/test/tests/Specs/Knit.spec.lua
+++ b/test/tests/Specs/Knit.spec.lua
@@ -1,7 +1,7 @@
 return function()
 
 	local Knit = require(game:GetService("ReplicatedStorage").Knit)
-	local RemoteEvent = require(Knit.Util.Remote.RemoteEvent)
+	local RemoteSignal = require(Knit.Util.Remote.RemoteSignal)
 	local RemoteProperty = require(Knit.Util.Remote.RemoteProperty)
 
 	local IS_SERVER = game:GetService("RunService"):IsServer()
@@ -15,7 +15,7 @@ return function()
 			Name = "AnotherService";
 			ABC = 32;
 			Client = {
-				TestEvent = RemoteEvent.new();
+				TestEvent = RemoteSignal.new();
 				TestProp = RemoteProperty.new(10);
 			}
 		}


### PR DESCRIPTION
Rename RemoteEvent to RemoteSignal for the sake of naming consistencies. This has obvious backwards-compatibility issues. The fix is to simply rename any references of RemoteEvent to RemoteSignal. There are no behavior changes.