### PR TITLE
Enhanced AddServices/AddControllers + Deep

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,5 +1,5 @@
 [tools]
 # Install latest selene
 selene = { source = "Kampfkarren/selene", version = "x" }
-rojo = { source = "rojo-rbx/rojo", version = "0.5.4" }
+rojo = { source = "rojo-rbx/rojo", version = "6.0.0-rc.4" }
 remodel = { source = "rojo-rbx/remodel", version = "0.7.1"}

--- a/src/Knit/KnitClient.lua
+++ b/src/Knit/KnitClient.lua
@@ -82,14 +82,10 @@ function KnitClient.CreateController(controller)
 end
 
 
-function KnitClient.AddControllers(folder)
-	return Loader.LoadChildren(folder)
-end
+KnitClient.AddControllers = Loader.LoadChildren
 
 
-function KnitClient.AddControllersDeep(folder)
-	return Loader.LoadDescendants(folder)
-end
+KnitClient.AddControllersDeep = Loader.LoadDescendants
 
 
 function KnitClient.GetService(serviceName)

--- a/src/Knit/KnitServer.lua
+++ b/src/Knit/KnitServer.lua
@@ -98,14 +98,10 @@ function KnitServer.CreateService(service)
 end
 
 
-function KnitServer.AddServices(folder)
-	return Loader.LoadChildren(folder)
-end
+KnitServer.AddServices = Loader.LoadChildren
 
 
-function KnitServer.AddServicesDeep(folder)
-	return Loader.LoadDescendants(folder)
-end
+KnitServer.AddServicesDeep = Loader.LoadDescendants
 
 
 function KnitServer.BindRemoteEvent(service, eventName, remoteEvent)

--- a/src/Knit/Util/Loader.lua
+++ b/src/Knit/Util/Loader.lua
@@ -19,7 +19,7 @@ function Loader.LoadChildren(parent)
 	local modules = {}
 	for _,child in ipairs(parent:GetChildren()) do
 		if (child:IsA("ModuleScript")) then
-			local m = require(child)
+			local _, m = pcall(require, child)
 			table.insert(modules, m)
 		end
 	end
@@ -31,7 +31,7 @@ function Loader.LoadDescendants(parent)
 	local modules = {}
 	for _,descendant in ipairs(parent:GetDescendants()) do
 		if (descendant:IsA("ModuleScript")) then
-			local m = require(descendant)
+			local _, m = pcall(require, descendant)
 			table.insert(modules, m)
 		end
 	end


### PR DESCRIPTION
Wrapping the require in a pcall will remove the extra debug message left by the error in the loader. This will still keep the stack trace for the original error, in the service.

I'm sure you are aware that thread.spec has an infinite yield and doesn't work. The unit tests don't seem completed anyway but just wanted to notify you.

On top of this, I've also commented in the discord, not sure if you saw. Knit.AddServices/AddControllers I believe should accept an array of instances (it will filter for modulescripts), it just makes more sense. And with that, you can add an overload to accept an object as a parameter. Then even a second parameter optionally stating if you want it to recurse through all descendants.
TBH though, I think it will make more sense just naming it LoadModules, since it requires and loads all the modules. 