### PR TITLE
Remove ref to nil field

### DIFF
--- a/src/Knit/Util/Remote/ClientRemoteProperty.lua
+++ b/src/Knit/Util/Remote/ClientRemoteProperty.lua
@@ -60,7 +60,6 @@ end
 
 function ClientRemoteProperty:Destroy()
 	self._change:Disconnect()
-	self._set:Destroy()
 	if (self._isTable) then
 		self.Changed:Destroy()
 	end


### PR DESCRIPTION
The line `self._set:Destroy()` was throwing errors because `_set` doesn't exist. Line has been removed. `_set` had existed in a previous version and its removal was overlooked previously.