### PR TITLE
Dark theme support based on preference

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
   palette:
     primary: indigo
     accent: light blue
+    scheme: preference
   highlightjs: true
   hljs_languages:
     - lua


### PR DESCRIPTION
Knit's documentation is a health hazard. I believe I'm suffering from eye fatigue looking at the bright white colors.

This will acknowledge any health concerns as well as provide a seamless reading experience.