### PR TITLE
Signal proxy

### DIFF
--- a/docs/util.md
+++ b/docs/util.md
@@ -25,6 +25,12 @@ connection:Disconnect()
 
 The Connection object internal to the Signal module also has a Destroy method associated with it, so it will still play nicely with the Maid module.
 
+It is possible to wrap an existing RBXScriptSignal (e.g. `BasePart.Touched`) using `Signal.Proxy`, which is useful when creating abstractions that utilize existing built-in signals:
+
+```lua
+local touchTap = Signal.Proxy(UserInputService.TouchTap)
+```
+
 --------------------
 
 ## [Thread](https://github.com/Sleitnick/Knit/blob/main/src/Knit/Util/Thread.lua)

--- a/src/Knit/Util/Signal.lua
+++ b/src/Knit/Util/Signal.lua
@@ -4,7 +4,10 @@
 
 --[[
 
-	signal = Signal.new([maid])
+	signal = Signal.new([maid: Maid])
+	signal = Signal.Proxy(rbxSignal: RBXScriptSignal [, maid: Maid])
+
+	Signal.Is(object: any): boolean
 
 	signal:Fire(...)
 	signal:Wait()
@@ -12,7 +15,7 @@
 	signal:Destroy()
 	signal:DisconnectAll()
 	
-	connection = signal:Connect(functionHandler)
+	connection = signal:Connect((...) -> void)
 
 	connection:Disconnect()
 	connection:IsConnected()
@@ -80,8 +83,33 @@ function Signal.new(maid)
 end
 
 
+function Signal.Proxy(rbxScriptSignal, maid)
+	assert(typeof(rbxScriptSignal) == "RBXScriptSignal", "Argument #1 must be of type RBXScriptSignal")
+	local signal = Signal.new(maid)
+	signal:_setProxy(rbxScriptSignal)
+	return signal
+end
+
+
 function Signal.Is(obj)
 	return (type(obj) == "table" and getmetatable(obj) == Signal)
+end
+
+
+function Signal:_setProxy(rbxScriptSignal)
+	assert(typeof(rbxScriptSignal) == "RBXScriptSignal", "Argument #1 must be of type RBXScriptSignal")
+	self:_clearProxy()
+	self._proxyHandle = rbxScriptSignal:Connect(function(...)
+		self:Fire(...)
+	end)
+end
+
+
+function Signal:_clearProxy()
+	if (self._proxyHandle) then
+		self._proxyHandle:Disconnect()
+		self._proxyHandle = nil
+	end
 end
 
 
@@ -142,6 +170,7 @@ end
 
 function Signal:Destroy()
 	self:DisconnectAll()
+	self:_clearProxy()
 	self._bindable:Destroy()
 end
 


### PR DESCRIPTION
Add constructor to create simple proxy signal to a built-in RBXScriptSignal.