### PR TITLE
Add Knit.GetService for services

### DIFF
--- a/docs/knitapi.md
+++ b/docs/knitapi.md
@@ -159,7 +159,6 @@ Knit.AddControllersDeep(replicatedStorage.MyControllers)
 ```
 
 ### `Knit.GetService(serviceName: string)` -> `ServiceMirror`
-[Client-side only]
 
 Returns a [ServiceMirror](#servicemirror) table object representing the service. Service methods and events that have been exposed to the client can be used from this returned object.
 

--- a/src/Knit/KnitServer.lua
+++ b/src/Knit/KnitServer.lua
@@ -108,6 +108,12 @@ function KnitServer.AddServicesDeep(folder)
 end
 
 
+function KnitServer.GetService(serviceName)
+	assert(type(serviceName) == "string", "ServiceName must be a string; got " .. type(serviceName))
+	return assert(KnitServer.Services[serviceName], "Could not find service \"" .. serviceName .. "\"")
+end
+
+
 function KnitServer.BindRemoteEvent(service, eventName, remoteEvent)
 	assert(service._knit_re[eventName] == nil, "RemoteEvent \"" .. eventName .. "\" already exists")
 	local re = remoteEvent._remote

--- a/src/Knit/Util/Loader.lua
+++ b/src/Knit/Util/Loader.lua
@@ -3,12 +3,9 @@
 -- January 10, 2021
 
 --[[
-
 	Loads all ModuleScripts within the given parent.
-
 	Loader.LoadChildren(parent: Instance): module[]
 	Loader.LoadDescendants(parent: Instance): module[]
-
 --]]
 
 
@@ -17,12 +14,10 @@ local Loader = {}
 
 function Loader.LoadChildren(parent)
 	local modules = {}
-	local n = 0
 	for _,child in ipairs(parent:GetChildren()) do
 		if (child:IsA("ModuleScript")) then
 			local m = require(child)
-			n += 1
-			modules[n] = m
+			table.insert(modules, m)
 		end
 	end
 	return modules
@@ -31,12 +26,10 @@ end
 
 function Loader.LoadDescendants(parent)
 	local modules = {}
-	local n = 0
 	for _,descendant in ipairs(parent:GetDescendants()) do
 		if (descendant:IsA("ModuleScript")) then
 			local m = require(descendant)
-			n += 1
-			modules[n] = m
+			table.insert(modules, m)
 		end
 	end
 	return modules

--- a/src/Knit/Util/Loader.lua
+++ b/src/Knit/Util/Loader.lua
@@ -17,10 +17,12 @@ local Loader = {}
 
 function Loader.LoadChildren(parent)
 	local modules = {}
+	local n = 0
 	for _,child in ipairs(parent:GetChildren()) do
 		if (child:IsA("ModuleScript")) then
 			local m = require(child)
-			table.insert(modules, m)
+			n += 1
+			modules[n] = m
 		end
 	end
 	return modules
@@ -29,10 +31,12 @@ end
 
 function Loader.LoadDescendants(parent)
 	local modules = {}
+	local n = 0
 	for _,descendant in ipairs(parent:GetDescendants()) do
 		if (descendant:IsA("ModuleScript")) then
 			local m = require(descendant)
-			table.insert(modules, m)
+			n += 1
+			modules[n] = m
 		end
 	end
 	return modules

--- a/src/Knit/Util/Loader.lua
+++ b/src/Knit/Util/Loader.lua
@@ -3,9 +3,12 @@
 -- January 10, 2021
 
 --[[
+
 	Loads all ModuleScripts within the given parent.
+
 	Loader.LoadChildren(parent: Instance): module[]
 	Loader.LoadDescendants(parent: Instance): module[]
+
 --]]
 
 

--- a/src/Knit/Util/TableUtil.lua
+++ b/src/Knit/Util/TableUtil.lua
@@ -304,7 +304,7 @@ end
 
 local function Map(t, f)
 	assert(type(t) == "table", "First argument must be a table")
-	assert(type(f) == "function", "Second argument must be an array")
+	assert(type(f) == "function", "Second argument must be a function")
 	local newT = table.create(#t)
 	for k,v in pairs(t) do
 		newT[k] = f(v, k, t)
@@ -315,20 +315,18 @@ end
 
 local function Filter(t, f)
 	assert(type(t) == "table", "First argument must be a table")
-	assert(type(f) == "function", "Second argument must be an array")
+	assert(type(f) == "function", "Second argument must be a function")
 	local newT = table.create(#t)
 	if (#t > 0) then
 		local n = 0
-		for i = 1,#t do
-			local v = t[i]
-			if (f(v, i, t)) then
-				n = (n + 1)
-				newT[n] = v
+		for i,v in ipairs(t) do
+			if f(v, i, t) then
+				newT[i] = v
 			end
 		end
 	else
 		for k,v in pairs(t) do
-			if (f(v, k, t)) then
+			if f(v, k, t) then
 				newT[k] = v
 			end
 		end
@@ -339,7 +337,7 @@ end
 
 local function Reduce(t, f, init)
 	assert(type(t) == "table", "First argument must be a table")
-	assert(type(f) == "function", "Second argument must be an array")
+	assert(type(f) == "function", "Second argument must be a function")
 	assert(init == nil or type(init) == "number", "Third argument must be a number or nil")
 	local result = (init or 0)
 	for k,v in pairs(t) do


### PR DESCRIPTION
As the root of many bugs, being able to use Knit.GetService in another service is a commonly requested feature. Alternatively, we can add a warning in place of the return.