### PR TITLE
Added support for tables with .Disconnect method [Maid]

### DIFF
--- a/src/Util/Maid.lua
+++ b/src/Util/Maid.lua
@@ -68,7 +68,7 @@ function Maid:__newindex(index, newTask)
 	if (oldTask) then
 		if (type(oldTask) == "function") then
 			oldTask()
-		elseif (typeof(oldTask) == "RBXScriptConnection") then
+		elseif (typeof(oldTask) == "RBXScriptConnection" or (typeof(oldTask) == "table" and oldTask.Disconnect)) then
 			oldTask:Disconnect()
 		elseif (oldTask.Destroy) then
 			oldTask:Destroy()
@@ -88,8 +88,8 @@ function Maid:GiveTask(task)
 	local taskId = (#self._tasks + 1)
 	self[taskId] = task
 
-	if (type(task) == "table" and (not task.Destroy) and (not Promise.Is(task))) then
-		warn("[Maid.GiveTask] - Gave table task without .Destroy\n\n" .. debug.traceback())
+	if (type(task) == "table" and not (task.Destroy or task.Disconnect) and (not Promise.Is(task))) then
+		warn("[Maid.GiveTask] - Table task must have a Destroy or Disconnect method \n\n" .. debug.traceback())
 	end
 
 	return taskId
@@ -117,7 +117,7 @@ function Maid:DoCleaning()
 
 	-- Disconnect all events first as we know this is safe
 	for index, task in pairs(tasks) do
-		if (typeof(task) == "RBXScriptConnection") then
+		if (typeof(task) == "RBXScriptConnection" or (typeof(oldTask) == "table" and oldTask.Disconnect))  then
 			tasks[index] = nil
 			task:Disconnect()
 		end
@@ -129,7 +129,7 @@ function Maid:DoCleaning()
 		tasks[index] = nil
 		if (type(task) == "function") then
 			task()
-		elseif (typeof(task) == "RBXScriptConnection") then
+		elseif (typeof(task) == "RBXScriptConnection" or (typeof(oldTask) == "table" and oldTask.Disconnect)) then
 			task:Disconnect()
 		elseif (task.Destroy) then
 			task:Destroy()
@@ -144,5 +144,8 @@ end
 --- Alias for DoCleaning()
 -- @function Destroy
 Maid.Destroy = Maid.DoCleaning
+--- Alias for DoCleaning()
+-- @function Cleanup
+Maid.Cleanup = Maid.DoCleaning
 
 return Maid


### PR DESCRIPTION
Added support for tables with `.Disconnect` method, and is needed to work on signals exposed by a profile loaded from ProfileService. For example, a profile has a `MetaTagsUpdated` signal, which returns a table with a `.Disconnect` method rather than a `.Destroy` method and Maid won't clean it up upon calling `DoCleaning` or `Destroy` on the maid object. This commit fixes this issue. 

Also added `Maid.Cleanup` as a alias for `Maid.DoCleaning`, since `Maid.Cleanup` looks a lot clean as well and not a lot of people (including me) like to ruin my code's consistency.