### PR TITLE
Added support for tables with .Disconnect method

### DIFF
--- a/src/Util/Maid.lua
+++ b/src/Util/Maid.lua
@@ -72,6 +72,8 @@ function Maid:__newindex(index, newTask)
 			oldTask:Disconnect()
 		elseif (oldTask.Destroy) then
 			oldTask:Destroy()
+		elseif (oldTask.Disconnect) then
+			oldTask:Disconnect()
 		elseif (Promise.Is(oldTask)) then
 			oldTask:Cancel()
 		end
@@ -88,8 +90,8 @@ function Maid:GiveTask(task)
 	local taskId = (#self._tasks + 1)
 	self[taskId] = task
 
-	if (type(task) == "table" and (not task.Destroy) and (not Promise.Is(task))) then
-		warn("[Maid.GiveTask] - Gave table task without .Destroy\n\n" .. debug.traceback())
+	if (type(task) == "table" and not (task.Destroy or task.Disconnect) and (not Promise.Is(task))) then
+		warn("[Maid.GiveTask] - Gave table task without .Destroy or .Disconnect\n\n" .. debug.traceback())
 	end
 
 	return taskId
@@ -133,6 +135,8 @@ function Maid:DoCleaning()
 			task:Disconnect()
 		elseif (task.Destroy) then
 			task:Destroy()
+		elseif (task.Disconnect) then
+			task:Disconnect()
 		elseif (Promise.Is(task)) then
 			task:Cancel()
 		end
@@ -144,5 +148,9 @@ end
 --- Alias for DoCleaning()
 -- @function Destroy
 Maid.Destroy = Maid.DoCleaning
+
+--- Alias for DoCleaning()
+-- @function Cleanup
+Maid.Cleanup = Maid.DoCleaning
 
 return Maid


### PR DESCRIPTION
Added support for tables with `.Disconnect` method, and is needed to work on signals exposed by a profile loaded from ProfileService. For example, a profile has a `MetaTagsUpdated` signal, which returns a table with a `.Disconnect` method rather than a `.Destroy` method and Maid won't clean it up upon calling `DoCleaning` or `Destroy` on the maid object. This commit fixes this issue. 

Also added `Maid.Cleanup` as a alias for `Maid.DoCleaning`, since `Maid.Cleanup` looks a lot clean as well and not a lot of people (including me) like to ruin my code's consistency.