### PR TITLE
Destroy components when the parent changes.

### DIFF
--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -377,6 +377,13 @@ function Component:_instanceAdded(instance)
 			obj:Init()
 		end)
 	end
+	self._maid:GiveTask(instance:GetPropertyChangedSignal("Parent"):Connect(function()
+		if (IsDescendantOfWhitelist(instance)) then
+			self:_instanceAdded(instance)
+		else
+			self:_instanceRemoved(instance)
+		end
+	end))
 	self.Added:Fire(obj)
 	return obj
 end

--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -377,13 +377,18 @@ function Component:_instanceAdded(instance)
 			obj:Init()
 		end)
 	end
-	self._maid:GiveTask(instance:GetPropertyChangedSignal("Parent"):Connect(function()
+	local parentConnection; parentConnection = instance:GetPropertyChangedSignal("Parent"):Connect(function()
+		if not CollectionService:HasTag(instance, self._tag) then
+			parentConnection:Disconnect()
+			return
+		end
 		if (IsDescendantOfWhitelist(instance)) then
 			self:_instanceAdded(instance)
 		else
 			self:_instanceRemoved(instance)
 		end
-	end))
+	end)
+	self._maid:GiveTask(parentConnection)
 	self.Added:Fire(obj)
 	return obj
 end

--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -367,9 +367,9 @@ function Component:_instanceAdded(instance)
 		instance:SetAttribute(ATTRIBUTE_ID_NAME, id)
 	end
 	local obj = self._class.new(instance)
+	local parentConnectionMaid = Maid.new()
 	obj.Instance = instance
 	obj._id = id
-	obj._parentConnectionMaid = Maid.new()
 	self._instancesToObjects[instance] = obj
 	table.insert(self._objects, obj)
 	if (self._hasInit) then
@@ -378,15 +378,15 @@ function Component:_instanceAdded(instance)
 			obj:Init()
 		end)
 	end
-	obj._parentConnectionMaid:GiveTask(self.Removed:Connect(function(object)
+	parentConnectionMaid:GiveTask(self.Removed:Connect(function(object)
 		local hasTag = (instance and CollectionService:HasTag(instance, self._tag) or false)
 		if ((object.Instance == instance) and (not hasTag)) then
-			obj._parentConnectionMaid:DoCleaning()
+			parentConnectionMaid:DoCleaning()
 		end
 	end))
-	obj._parentConnectionMaid:GiveTask(instance:GetPropertyChangedSignal("Parent"):Connect(function()
+	parentConnectionMaid:GiveTask(instance:GetPropertyChangedSignal("Parent"):Connect(function()
 		if ((not instance.Parent) or (not CollectionService:HasTag(instance, self._tag))) then
-			obj._parentConnectionMaid:DoCleaning()
+			parentConnectionMaid:DoCleaning()
 			return
 		end
 		if (IsDescendantOfWhitelist(instance)) then
@@ -395,7 +395,7 @@ function Component:_instanceAdded(instance)
 			self:_instanceRemoved(instance)
 		end
 	end))
-	self._maid:GiveTask(obj._parentConnectionMaid)
+	self._maid:GiveTask(parentConnectionMaid)
 	self.Added:Fire(obj)
 	return obj
 end

--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -379,8 +379,8 @@ function Component:_instanceAdded(instance)
 		end)
 	end
 	parentConnectionMaid:GiveTask(self.Removed:Connect(function(object)
-		local hasTag = (instance and CollectionService:HasTag(instance, self._tag) or false)
-		if ((object.Instance == instance) and (not hasTag)) then
+		if (not (object.Instance == instance)) then return end
+		if (not (instance and CollectionService:HasTag(instance, self._tag))) then
 			parentConnectionMaid:DoCleaning()
 		end
 	end))
@@ -389,10 +389,9 @@ function Component:_instanceAdded(instance)
 			parentConnectionMaid:DoCleaning()
 			return
 		end
-		if (IsDescendantOfWhitelist(instance)) then
-			self:_instanceAdded(instance)
-		else
+		if (not IsDescendantOfWhitelist(instance)) then
 			self:_instanceRemoved(instance)
+			parentConnectionMaid:DoCleaning()
 		end
 	end))
 	self._maid:GiveTask(parentConnectionMaid)

--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -378,7 +378,7 @@ function Component:_instanceAdded(instance)
 		end)
 	end
 	local parentConnection; parentConnection = instance:GetPropertyChangedSignal("Parent"):Connect(function()
-		if not CollectionService:HasTag(instance, self._tag) then
+		if (not CollectionService:HasTag(instance, self._tag)) then
 			parentConnection:Disconnect()
 			return
 		end

--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -379,7 +379,7 @@ function Component:_instanceAdded(instance)
 		end)
 	end
 	parentConnectionMaid:GiveTask(self.Removed:Connect(function(object)
-		if (not (object.Instance == instance)) then return end
+		if (object.Instance ~= instance) then return end
 		if (not (instance and CollectionService:HasTag(instance, self._tag))) then
 			parentConnectionMaid:DoCleaning()
 		end


### PR DESCRIPTION
Components should be destroyed for instances when re-parented out of the whitelist. Should fix #109 