### PR TITLE
Fix copy and paste typo

### DIFF
--- a/docs/vscodesnippets.md
+++ b/docs/vscodesnippets.md
@@ -127,7 +127,7 @@ return MyService
 -------------------------------------
 
 ### Knit Controller
-Reference Knit, create a service, and return the service.
+Reference Knit, create a controller, and return the controller.
 <details class="note">
 <summary>Snippet</summary>
 


### PR DESCRIPTION
Knit Controller documentation was the same as the Knit Service documentation, due to copy and pasting the same text