### PR TITLE
Remove redundant loop in Component module

### DIFF
--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -261,9 +261,6 @@ function Component.new(tag, class, renderPriority, requireComponents)
 	else
 		-- Only observe tag when all required components are available:
 		local tagsReady = {}
-		for _,reqComp in ipairs(self._requireComponents) do
-			tagsReady[reqComp] = false
-		end
 		local function Check()
 			for _,ready in pairs(tagsReady) do
 				if (not ready) then


### PR DESCRIPTION
The logic done in this loop is already done in a later stage. It does not need to happen twice.