### PR TITLE
Add Remote support to Components

### DIFF
--- a/src/Util/Component.lua
+++ b/src/Util/Component.lua
@@ -81,8 +81,11 @@
 
 local Janitor = require(script.Parent.Janitor)
 local Signal = require(script.Parent.Signal)
+local Ser = require(script.Parent.Ser)
 local Promise = require(script.Parent.Promise)
 local TableUtil = require(script.Parent.TableUtil)
+local RemoteSignal = require(script.Parent.Remote.RemoteSignal)
+local ClientRemoteSignal = require(script.Parent.Remote.ClientRemoteSignal)
 local CollectionService = game:GetService("CollectionService")
 local RunService = game:GetService("RunService")
 local Players = game:GetService("Players")
@@ -90,6 +93,14 @@ local Players = game:GetService("Players")
 local IS_SERVER = RunService:IsServer()
 local DEFAULT_WAIT_FOR_TIMEOUT = 60
 local ATTRIBUTE_ID_NAME = "ComponentServerId"
+local COMPONENT_REMOTES_FOLDER_NAME = "ComponentRemotes"
+local COMPONENT_REMOTES_LOCATION;
+if (IS_SERVER) then
+	COMPONENT_REMOTES_LOCATION = Instance.new("Folder", game:GetService("ReplicatedStorage").Knit)
+	COMPONENT_REMOTES_LOCATION.Name = COMPONENT_REMOTES_FOLDER_NAME
+else
+	game:GetService("ReplicatedStorage").Knit:WaitForChild(COMPONENT_REMOTES_FOLDER_NAME))
+end
 
 local Component = {}
 Component.__index = Component
@@ -188,7 +199,55 @@ function Component.new(tag, class, renderPriority, requireComponents)
 	self._janitor:Add(observeJanitor)
 	self._janitor:Add(self._lifecycleJanitor)
 
+	local function CreateRemotesIfTheyExist()
+		if (IS_SERVER and self._class.Client) then
+            
+		local ComponentFolder = Instance.new("Folder")
+		ComponentFolder.Name = self._tag
+		
+		local function BindRemoteEvent(eventName, remoteEvent)
+			assert(ComponentFolder:FindFirstChild(eventName) == nil, "RemoteEvent \"" .. eventName .. "\" already exists")
+			local function onRemoteEvent(Player, Instance, ...)
+				local ServerComponent = self:GetFromInstance(Instance)
+				if (ServerComponent) then
+					local func = ServerComponent._remoteConnections[eventName]
+					if (func) then
+						func(Player, Ser.DeserializeArgsAndUnpack(...))
+					end
+				end
+			end
+			remoteEvent:Connect(onRemoteEvent)
+                	local re = remoteEvent._remote
+                	re.Name = eventName
+                	re.Parent = ComponentFolder
+		end
+		
+		local function BindRemoteFunction(funcName, func)
+			assert(ComponentFolder:FindFirstChild(funcName) == nil, "RemoteFunction \"" .. funcName .. "\" already exists")
+			local rf = Instance.new("RemoteFunction", ComponentFolder)
+			rf.Name = funcName
+			function rf.OnServerInvoke(Player, Instance, ...)
+				local ServerComponent = self:GetFromInstance(Instance)
+				if (not ServerComponent) then warn("Server Component does not exist!") return nil end
+				return Ser.SerializeArgsAndUnpack(ServerComponent.Client[funcName](ServerComponent.Client, Player, Ser.DeserializeArgsAndUnpack(...)))
+			end
+		end
+
+            	for k,v in pairs(self._class.Client) do
+			if (type(v)=="function") then
+				BindRemoteFunction(k, v)
+                	elseif (RemoteSignal.Is(v)) then
+                    		BindRemoteEvent(k, v)
+                	end
+            	end
+        	ComponentFolder.Parent = COMPONENT_REMOTES_LOCATION
+		self._janitor:Add(ComponentFolder)
+            end
+	end
+
 	local function ObserveTag()
+
+		CreateRemotesIfTheyExist()
 
 		local function HasRequiredComponents(instance)
 			for _,reqComp in ipairs(self._requireComponents) do
@@ -355,14 +414,53 @@ function Component:_instanceAdded(instance)
 	end
 	self._nextId = (self._nextId + 1)
 	local id = (self._tag .. tostring(self._nextId))
-	if (IS_SERVER) then
-		instance:SetAttribute(ATTRIBUTE_ID_NAME, id)
-	end
 	local obj = self._class.new(instance)
 	obj.Instance = instance
 	obj._id = id
 	self._instancesToObjects[instance] = obj
 	table.insert(self._objects, obj)
+	if (IS_SERVER) then
+		instance:SetAttribute(ATTRIBUTE_ID_NAME, id)
+		if (self._class.Client) then
+			obj._remoteConnections = {}
+			for k,v in pairs(self._class.Client) do
+				if (RemoteSignal.Is(v)) then
+					obj.Client[k].Connect = function(_self, callback)
+						obj._remoteConnections[k] = function(...)
+							return callback(...)
+						end
+					end
+				end
+			end
+			obj.Client.Server = obj
+		end
+	else
+		local ComponentFolder = COMPONENT_REMOTES_LOCATION:FindFirstChild(self._tag)
+        	if (ComponentFolder) then
+
+            	self._class.Server = {}
+
+            	for k,v in pairs(ComponentFolder:GetChildren()) do
+                	if (v:IsA("RemoteEvent")) then
+                    		local remoteSignal = ClientRemoteSignal.new(v)
+                    		function remoteSignal:Fire(...)
+                        		self._remote:FireServer(instance, Ser.SerializeArgsAndUnpack(...))
+                    		end
+                    		self._class.Server[v.Name] = remoteSignal
+                	elseif (v:IsA("RemoteFunction")) then
+                    		self._class.Server[v.Name] = function(self, ...)
+					return Ser.DeserializeArgsAndUnpack(v:InvokeServer(instance, Ser.SerializeArgsAndUnpack(...)))
+				end
+				self._class.Server["Promise"..v.Name] = function(self, ...)
+					local args = Ser.SerializeArgs(...)
+					return Promise.new(function(resolve)
+							resolve(Ser.DeserializeArgsAndUnpack(v:InvokeServer(instance, table.unpack(args, 1, args.n))))
+						end)
+				end
+			end
+		end
+        end
+	end
 	if (self._hasInit) then
 		task.defer(function()
 			if (self._instancesToObjects[instance] ~= obj) then return end


### PR DESCRIPTION
Components are too cumbersome to use across the server boundary. This pull request seeks to remedy that by introducing:

1. An optional client table for the server component
2. If the client table is provided, a server table for the client component similar to how Knit already works
3. Instance filtering for the remotes so that no excess remotes are needed

The fork I made [here](https://github.com/EncodedVenom/RemoteComponent) has examples of this behavior.

I also considered potentially adding hashing support, but this is already a step forward for components.

I also do not expect this to be the final version of this pull request as many changes will probably take place.