### PR TITLE
Fix CopyTable and Sync methods not accounting for cyclic tables

### DIFF
--- a/src/Util/TableUtil.lua
+++ b/src/Util/TableUtil.lua
@@ -47,12 +47,14 @@ local HttpService = game:GetService("HttpService")
 local rng = Random.new()
 
 
-local function CopyTable(t: Table, cache): Table
+local function CopyTable(t: Table): Table
 	assert(type(t) == "table", "First argument must be a table")
 	
-	cache = cache or {}
 	
-	local function Copy(tbl)
+	
+	local function Copy(tbl, cache)
+		cache = cache or {}
+		
 		local tCopy = table.create(#tbl)
 		for k,v in pairs(tbl) do
 			if type(v) == "table" and not cache[v] then


### PR DESCRIPTION
The CopyTable and Sync methods don't account for cyclic tables and will cause a stackoverflow as of result. This pull request fixes this issue.