### PR TITLE
Replace '.Controllers' with '.GetController'

### DIFF
--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -123,7 +123,7 @@ Other code could then listen in for that event:
 
 ```lua
 -- Somewhere else on the client
-local CameraController = Knit.Controllers.CameraController
+local CameraController = Knit.GetController("CameraController")
 
 CameraController.LockedChanged:Connect(function(isLocked)
 	print(isLocked and "Camera is now locked" or "Camera was unlocked")


### PR DESCRIPTION
Example contains use case where the expression 'Knit.Controllers.CameraController' is used, which does not work in current Knit versions. Replaced documentation with 'Knit.GetController("CameraController")'.