### PR TITLE
Docs: Removed Knit.Services.Service in favour of Knit.GetService()

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -100,7 +100,7 @@ Another service could then listen for the changes on that event:
 
 ```lua
 function SomeOtherService:KnitStart()
-	local PointsService = Knit.Services.PointsService
+	local PointsService = Knit.GetService("PointsService")
 	PointsService.PointsChanged:Connect(function(player, points)
 		print("Points changed for " .. player.Name .. ":", points)
 	end)


### PR DESCRIPTION
One part of the docs was still doing Knit.Services.PointService which is not doable in Knit anymore.