### PR TITLE
Fixed requiring in Edit mode

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1,8 +1,12 @@
 if game:GetService("RunService"):IsServer() then
 	return require(script.KnitServer)
 else
+	local _, notInEdit = pcall(function()
+		game:GetService("RunService"):IsEdit()
+	end)
+	
 	local KnitServer = script:FindFirstChild("KnitServer")
-	if KnitServer then
+	if KnitServer and notInEdit then
 		KnitServer:Destroy()
 	end
 	return require(script.KnitClient)


### PR DESCRIPTION
When Knit got required from Edit Mode (E.g a plugin) it still decided to delete the KnitServer file. By adding a RunService check this problem is fixed!

This bug was really annoying when using for example Hoarcekat in my case. When one of my Roact Components where requiring Knit it deleted my KnitServer, making the game unplayable.