### PR TITLE
Prevent KnitServer from being destroyed when in EditMode

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1,10 +1,14 @@
 local RunService = game:GetService("RunService")
 
+local IS_EDIT = pcall(function()
+	RunService:IsEdit()
+end)
+
 if RunService:IsServer() then
 	return require(script.KnitServer)
 else
 	local KnitServer = script:FindFirstChild("KnitServer")
-	if KnitServer then
+	if KnitServer and not IS_EDIT then
 		KnitServer:Destroy()
 	end
 	return require(script.KnitClient)

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,8 +1,9 @@
 local RunService = game:GetService("RunService")
 
-local IS_EDIT = pcall(function()
-	RunService:IsEdit()
+local success, v = pcall(function()
+	return RunService:IsEdit()
 end)
+local IS_EDIT = success and v
 
 if RunService:IsServer() then
 	return require(script.KnitServer)


### PR DESCRIPTION
This commit stems from an issue where if Knit is ever even required inside of a module that is used within a plugin like Hoarcekat, it deletes KnitServer from your game. This small change aims to prevent that