### PR TITLE
Added support for sub-tables within service.Client

### DIFF
--- a/src/KnitServer.lua
+++ b/src/KnitServer.lua
@@ -358,19 +358,19 @@ function KnitServer.Start(options: KnitOptions?)
 			local outbound = if middleware.Outbound ~= nil then middleware.Outbound else knitMiddleware.Outbound
 			service.Middleware = nil
 
-			local depth = {}
+			local subFolders = {}
 			local function recursive(t)
 				for k, v in t do
 					if type(v) == "function" then
-						service.KnitComm:WrapMethod(t, k, inbound, outbound, depth)
+						service.KnitComm:WrapMethod(t, k, inbound, outbound, subFolders)
 					elseif v == SIGNAL_MARKER then
-						t[k] = service.KnitComm:CreateSignal(k, inbound, outbound, depth)
+						t[k] = service.KnitComm:CreateSignal(k, inbound, outbound, subFolders)
 					elseif type(v) == "table" and v[1] == PROPERTY_MARKER then
-						t[k] = service.KnitComm:CreateProperty(k, v[2], inbound, outbound, depth)
+						t[k] = service.KnitComm:CreateProperty(k, v[2], inbound, outbound, subFolders)
 					elseif type(v) == "table" and k ~= "Server" then
-						table.insert(depth, k)
+						table.insert(subFolders, k)
 						recursive(v)
-						table.remove(depth)
+						table.remove(subFolders)
 					end
 				end
 			end


### PR DESCRIPTION
This involves a separate [Pull Request](https://github.com/Sleitnick/RbxUtil/pull/154) to RbxUtil. Please refer to that for details of the changes to the Comm library.

Within Knit, you cannot have any tables containing RemoteEvents, RemoteProperties or Methods within the `service.Client` table.

For example, the following code will generate a remote event for PlayerAdded, but **will not** generate one for Update:
```lua
Knit.CreateService({
	Name = "ExampleService",
	
	Client = {
		PlayerAdded = Knit.CreateSignal(),
		
		Data = {
			Update = Knit.CreateSignal(),
		},		
	}
})
```

This issue cannot be fixed within Knit on its own, but requires changing around the structure of Comm slightly. This update only adds, and is entirely optional in new features. There shouldn't be any changes to existing code.

The change involves doing a recursive search through `service.Client` and if a table is encountered, then the search depth increases. When a comm method is found, the new optional subFolders argument is used which creates folders within the main RemoteEvent, RemoteProperty and RemoteFunction folders to reflect the table structure.

The new service tree hierarchy can look like this with subfolders:
```
ExampleService (Folder)
└── RE (Folder)
    ├── Data (Folder)
    │   └── Update (RE)
    └── PlayerAdded (RE)
```

The fix relates mostly to Knit, and doesn't change any existing code since it's just a recursive wrapper on the existing code.