### PR TITLE
Fixed inconsistent syntax than example in docs/services.md

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -169,7 +169,7 @@ end)
 
 ### Events (Server-to-Client)
 
-We can use remote signals to fire events from the server to the clients. Continuing with the previous PointsService example, let's create a signal that fires when a client's points change. We can use `Knit:CreateSignal()` to indicate we want a signal created for the service.
+We can use remote signals to fire events from the server to the clients. Continuing with the previous PointsService example, let's create a signal that fires when a client's points change. We can use `Knit.CreateSignal()` to indicate we want a signal created for the service.
 
 ```lua
 local PointsService = Knit.CreateService {


### PR DESCRIPTION
In the description of Section "Events (Server-to-Client)", there is an inconsistent syntax; In the description it is `Knit:CreateSignal()`, whereas in the example code, it is `Knit.CreateSignal()`.