### PR TITLE
GetServices and GetControllers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Install Aftman
-      uses: ok-nick/setup-aftman@v0
+      uses: ok-nick/setup-aftman@v0.4.2
     - name: Lint
       run: |
         selene ./src
@@ -29,5 +29,5 @@ jobs:
     - uses: JohnnyMorganz/stylua-action@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        version: v0.19.1
+        version: v0.20.0
         args: --check ./src

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Aftman
-        uses: ok-nick/setup-aftman@v0
+        uses: ok-nick/setup-aftman@v0.4.2
       - name: Publish release to Wally
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.0
+- Adds `Knit.GetServices()` function server-side
+- Adds `Knit.GetControllers()` function client-side
+- Freezes `services`/`controllers` tables so that they can be safely returned in the functions listed above.
+- Update GitHub workflow dependencies
+
 ## 1.6.0
 
 - Add support for UnreliableRemoteEvents (using `Knit.CreateUnreliableSignal()` on server)

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -22,7 +22,7 @@ Installing Knit is very simple. Just drop the module into ReplicatedStorage. Kni
 
 **Rojo/Wally workflow:**
 
-- Add Knit to your `wally.toml` dependency list (e.g. `Knit = "sleitnick/knit@^1.6"`)
+- Add Knit to your `wally.toml` dependency list (e.g. `Knit = "sleitnick/knit@^1.7"`)
 - Require Knit like any other module grabbed from Wally
 
 	:::note Wally

--- a/src/KnitClient.lua
+++ b/src/KnitClient.lua
@@ -291,6 +291,14 @@ function KnitClient.GetController(controllerName: string): Controller
 end
 
 --[=[
+	Gets a table of all controllers.
+]=]
+function KnitClient.GetControllers(): { [string]: Controller }
+	assert(started, "Cannot call GetControllers until Knit has been started")
+	return controllers
+end
+
+--[=[
 	@return Promise
 	Starts Knit. Should only be called once per client.
 	```lua
@@ -313,6 +321,8 @@ function KnitClient.Start(options: KnitOptions?)
 	end
 
 	started = true
+
+	table.freeze(controllers)
 
 	if options == nil then
 		selectedOptions = defaultOptions

--- a/src/KnitServer.lua
+++ b/src/KnitServer.lua
@@ -240,6 +240,14 @@ function KnitServer.GetService(serviceName: string): Service
 end
 
 --[=[
+	Gets a table of all services.
+]=]
+function KnitServer.GetServices(): { [string]: Service }
+	assert(started, "Cannot call GetServices until Knit has been started")
+	return services
+end
+
+--[=[
 	@return SIGNAL_MARKER
 	Returns a marker that will transform the current key into
 	a RemoteSignal once the service is created. Should only
@@ -363,6 +371,8 @@ function KnitServer.Start(options: KnitOptions?)
 	end
 
 	started = true
+
+	table.freeze(services)
 
 	if options == nil then
 		selectedOptions = defaultOptions

--- a/src/wally.toml
+++ b/src/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sleitnick/knit"
 description = "Knit is a lightweight game framework"
-version = "1.6.0"
+version = "1.7.0"
 license = "MIT"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"


### PR DESCRIPTION
- Adds `GetServices()` and `GetControllers()` methods.
- Freeze `services` and `controllers` tables.

Note: This does _not_ include the client-side `services` table. In other words, `GetServices()` is a server-only method & not available on the client. Items in this table are lazy-initialized as accessed, and require lookup into the data model. Thus, there is no adequate way to get all of them with the current setup.