### PR TITLE
Load order and type addition

### DIFF
--- a/src/KnitClient.lua
+++ b/src/KnitClient.lua
@@ -367,19 +367,19 @@ function KnitClient.Start(options: KnitOptions?)
 		selectedOptions.PerServiceMiddleware = {}
 	end
 
-	local arrayControllers: { Controller } = {}
+	local sortedControllers: { Controller } = {}
 	for _, controller in KnitClient.GetControllers() do
-		table.insert(arrayControllers, controller)
+		table.insert(sortedControllers, controller)
 	end
-	table.sort(arrayControllers, function(s1, s2)
-		return (s1.LoadOrder or 0) < (s2.LoadOrder or 0)
+	table.sort(sortedControllers, function(c1, c2)
+		return (c1.LoadOrder or 0) < (c2.LoadOrder or 0)
 	end)
 
 	return Promise.new(function(resolve)
 		-- Init:
 		local promisesStartControllers = {}
 
-		for _, controller in arrayControllers do
+		for _, controller in sortedControllers do
 			if type(controller.KnitInit) == "function" then
 				table.insert(
 					promisesStartControllers,
@@ -395,7 +395,7 @@ function KnitClient.Start(options: KnitOptions?)
 		resolve(Promise.all(promisesStartControllers))
 	end):andThen(function()
 		-- Start:
-		for _, controller in arrayControllers do
+		for _, controller in sortedControllers do
 			if type(controller.KnitStart) == "function" then
 				task.spawn(function()
 					debug.setmemorycategory(controller.Name)

--- a/src/KnitServer.lua
+++ b/src/KnitServer.lua
@@ -410,11 +410,11 @@ function KnitServer.Start(options: KnitOptions?)
 		end
 	end
 
-	local arrayServices: { Service } = {}
+	local sortedServices: { Service } = {}
 	for _, service in KnitServer.GetServices() do
-		table.insert(arrayServices, service)
+		table.insert(sortedServices, service)
 	end
-	table.sort(arrayServices, function(s1, s2)
+	table.sort(sortedServices, function(s1, s2)
 		return (s1.LoadOrder or 0) < (s2.LoadOrder or 0)
 	end)
 
@@ -444,7 +444,7 @@ function KnitServer.Start(options: KnitOptions?)
 
 		-- Init:
 		local promisesInitServices = {}
-		for _, service in arrayServices do
+		for _, service in sortedServices do
 			if type(service.KnitInit) == "function" then
 				table.insert(
 					promisesInitServices,
@@ -460,7 +460,7 @@ function KnitServer.Start(options: KnitOptions?)
 		resolve(Promise.all(promisesInitServices))
 	end):andThen(function()
 		-- Start:
-		for _, service in arrayServices do
+		for _, service in sortedServices do
 			if type(service.KnitStart) == "function" then
 				task.spawn(function()
 					debug.setmemorycategory(service.Name)


### PR DESCRIPTION
Allows you to start services or controllers in a specified order. Changing the `LoadOrder` value when creating a service or controller determines the order in which it will be initialized. If nothing is entered the default value will be 0